### PR TITLE
[OWL-434] fixed Issue of missed tag info on event case generator

### DIFF
--- a/model/event/event.go
+++ b/model/event/event.go
@@ -2,11 +2,11 @@ package event
 
 import (
 	"fmt"
+	coommonModel "github.com/Cepave/common/model"
+	"github.com/Cepave/common/utils"
+	"github.com/astaxie/beego/orm"
 	"log"
 	"time"
-
-	coommonModel "github.com/Cepave/common/model"
-	"github.com/astaxie/beego/orm"
 )
 
 type Event struct {
@@ -59,7 +59,7 @@ func InsertEvent(eve *coommonModel.Event) {
 			sqltemplete,
 			eve.Id,
 			eve.Endpoint,
-			eve.Metric(),
+			counterGen(eve.Metric(), utils.SortedTags(eve.PushedTags)),
 			eve.Func(),
 			//cond
 			fmt.Sprintf("%v %v %v", eve.LeftValue, eve.Operator(), eve.RightValue()),
@@ -89,4 +89,12 @@ func InsertEvent(eve *coommonModel.Event) {
 		log.Printf("%v, %v", res, err)
 
 	}
+}
+
+func counterGen(metric string, tags string) (mycounter string) {
+	mycounter = metric
+	if tags != "" {
+		mycounter = fmt.Sprintf("%s/%s", metric, tags)
+	}
+	return
 }


### PR DESCRIPTION
修復寫入alarm case到db的時候metric會漏寫tag的問題
